### PR TITLE
fix: use relative import for background.css in Home.jsx

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import '/Users/melina/Documents/SideProjects/CareerCompass/client/src/background.css';
+import '../background.css';
 
 const orange = '#FF6E00';
 


### PR DESCRIPTION
1.) Got the error while attempting to run it on local host.
 Failed to resolve import "/Users/melina/Documents/SideProjects/CareerCompass/client/src/background.css" from "src/pages/Home.jsx". 
 
2.)Happens because in your cloned copy, Vite is trying to load a CSS file from an absolute path on Melina’s machine ( /Users/melina/... ) which of course doesn’t exist on my laptop. or other peoples laptops.
 
3.) Change the import in Home.jsx to a relative path
Open client/src/pages/Home.jsx, and replace the absolute import with something like:

diff
Copy
Edit
- import "/Users/melina/Documents/SideProjects/CareerCompass/client/src/background.css";
+ import "../background.css";

Worked after this small change.